### PR TITLE
build: add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/result

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 ### Installation
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/lemmy-help.svg)](https://repology.org/project/lemmy-help/versions)
+
 - Using `cargo`
 
 ```bash

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,64 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1696343447,
+        "narHash": "sha256-B2xAZKLkkeRFG5XcHHSXXcP7To9Xzr59KXeZiRf4vdQ=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "c9afaba3dfa4085dbd2ccb38dfade5141e33d9d4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1697379843,
+        "narHash": "sha256-RcnGuJgC2K/UpTy+d32piEoBXq2M+nVFzM3ah/ZdJzg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "12bdeb01ff9e2d3917e6a44037ed7df6e6c3df9d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1696019113,
+        "narHash": "sha256-X3+DKYWJm93DRSdC5M6K5hLqzSya9BjibtBsuARoPco=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f5892ddac112a1e9b3612c39af1b72987ee5783a",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,64 @@
+{
+  description = "A CLI to generate vim/nvim help doc from emmylua";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs @ {
+    self,
+    nixpkgs,
+    flake-parts,
+    ...
+  }:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      perSystem = {
+        config,
+        self',
+        inputs',
+        pkgs,
+        system,
+        ...
+      }: let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [
+            self.overlays.default
+          ];
+        };
+      in {
+        devShells.default = pkgs.mkShell {
+          name = "lemmyHelp devShell";
+          buildInputs = with pkgs;
+          with pkgs.rustPlatform; [
+            cargo
+            rustc
+            rustfmt
+            rust-analyzer
+          ];
+        };
+
+        packages = rec {
+          default = lemmy-help;
+          inherit (pkgs) lemmy-help;
+        };
+      };
+      flake = {
+        overlays.default = final: prev: {
+          lemmy-help = prev.lemmy-help.overrideAttrs (oa: {
+            src = self;
+            version = ((prev.lib.importTOML "${self}/Cargo.toml").package).version;
+            cargoDeps = prev.rustPlatform.importCargoLock {
+              lockFile = self + "/Cargo.lock";
+            };
+          });
+        };
+      };
+    };
+}


### PR DESCRIPTION
The flake provides:

- A nix shell (with development tools)
- Instructions for building lemmy-help from source (overriding the [nixpkgs build](https://search.nixos.org/packages?channel=unstable&show=lemmy-help&from=0&size=50&sort=relevance&type=packages&query=lemmy-help))