### PR TITLE
fix: func tag spillover if line == TW

### DIFF
--- a/src/vimdoc.rs
+++ b/src/vimdoc.rs
@@ -403,8 +403,9 @@ fn description(desc: &str, indent: usize) -> String {
 #[inline]
 fn header(name: &str, tag: &str) -> String {
     let len = name.len();
-    if len > 40 || tag.len() > 40 {
-        return format!("{:>w$}\n{}\n", format!("*{}*", tag), name, w = TW);
+    let tag_str = format!("*{}*", tag);
+    if len + tag_str.len() >= TW {
+        return format!("{:>w$}\n{}\n", tag_str, name, w = TW);
     }
-    format!("{}{:>w$}\n", name, format!("*{}*", tag), w = TW - len)
+    format!("{}{:>w$}\n", name, tag_str, w = TW - len)
 }

--- a/tests/golden/functions.lua
+++ b/tests/golden/functions.lua
@@ -64,4 +64,15 @@ function U.foo.baz()
     return U.foo:bar()
 end
 
+---Method with long name and signature just below tag spillover length
+function U.very_long_function_name____________() end
+---Method with long name and signature just above tag spillover length
+function U.very_long_function_name_____________() end
+---Method with long param and signature just below tag spillover length
+---@param long_param_name______________ string
+function U.short_function_name1(long_param_name______________) end
+---Method with long param and signature just above tag spillover length
+---@param long_param_name_______________ string
+function U.short_function_name2(long_param_name_______________) end
+
 return U

--- a/tests/golden/functions.txt
+++ b/tests/golden/functions.txt
@@ -73,4 +73,28 @@ U.foo.baz()                                                          *U.foo.baz*
         (table)
 
 
+U.very_long_function_name____________()  *U.very_long_function_name____________*
+    Method with long name and signature just below tag spillover length
+
+
+                                        *U.very_long_function_name_____________*
+U.very_long_function_name_____________()
+    Method with long name and signature just above tag spillover length
+
+
+U.short_function_name1({long_param_name______________}) *U.short_function_name1*
+    Method with long param and signature just below tag spillover length
+
+    Parameters: ~
+        {long_param_name______________}  (string)
+
+
+                                                        *U.short_function_name2*
+U.short_function_name2({long_param_name_______________})
+    Method with long param and signature just above tag spillover length
+
+    Parameters: ~
+        {long_param_name_______________}  (string)
+
+
 


### PR DESCRIPTION
Ran into an issue where you could get a line like this, without a space between the function signature and the tag, which would break the tag:

```vimdoc
U.very_long_function_name_____________()*U.very_long_function_name_____________*
```